### PR TITLE
Run update_dismiss on deactivated_plugin action

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -252,6 +252,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					add_action( 'admin_init', array( $this, 'admin_init' ), 1 );
 					add_action( 'admin_enqueue_scripts', array( $this, 'thickbox' ) );
 					add_action( 'switch_theme', array( $this, 'update_dismiss' ) );
+					add_action( 'deactivated_plugin', array( $this, 'update_dismiss' ) );
 				}
 
 				// Setup the force activation hook.


### PR DESCRIPTION
If user de-activates a recommended plugin after they have dismissed the notice it reminds them again that it's recommended.

https://github.com/thomasgriffin/TGM-Plugin-Activation/issues/266
